### PR TITLE
fix: prevent 409 by guarding re-submit of consumed Facebook OAuth state

### DIFF
--- a/resources/views/integrations/facebook/complete.blade.php
+++ b/resources/views/integrations/facebook/complete.blade.php
@@ -220,6 +220,7 @@ document.addEventListener('DOMContentLoaded', function () {
             successPanel.classList.remove('d-none');
             reconnectLink.textContent = 'Back to integrations';
             reconnectLink.classList.remove('d-none');
+            setTimeout(() => { window.location.href = @json($integrationsUrl); }, 1500);
         } catch (error) {
             showAlert('danger', 'Facebook setup is temporarily unavailable. Please try again.', true, false);
         } finally {

--- a/src/Http/Controllers/IntegrationConfigController.php
+++ b/src/Http/Controllers/IntegrationConfigController.php
@@ -309,7 +309,32 @@ class IntegrationConfigController extends Controller
             $validated = $request->validate([
                 'state' => 'required|string',
                 'page_id' => 'required|string',
+                'integration_id' => 'nullable|string',
             ]);
+
+            $integration = null;
+            if (!empty($validated['integration_id'])) {
+                $integration = Integration::where('uid', $validated['integration_id'])
+                    ->whereHas('supportedIntegration', function ($query) {
+                        $query->where('name', Constants::FACEBOOK_PAGE);
+                    })
+                    ->first();
+            }
+
+            if ($integration && $integration->getMeta('facebook_connection_status') === 'connected') {
+                Log::info('facebook_integration_save_skipped_already_connected', [
+                    'user_id' => auth()->id(),
+                    'integration_uid' => $integration->uid,
+                    'state_ref' => $this->stateRef($validated['state']),
+                ]);
+
+                return response()->json([
+                    'success' => true,
+                    'message' => 'Facebook connection already exists.',
+                    'page_id' => $integration->getMeta('facebook_page_id'),
+                    'page_name' => $integration->getMeta('facebook_page_name'),
+                ]);
+            }
 
             Log::info('facebook_integration_save_started', [
                 'user_id' => auth()->id(),


### PR DESCRIPTION
## Problem
The `/social/facebook/connect/complete` page kept the user on a URL that carried the OAuth `state`. Any page re-render (refresh, back button, browser retry) re-fired the save request with the same `state`, which chatbot-util rejected with **409 `facebook_save_already_completed`** because the state row was already marked `save_status=completed`.

## Fix
Two layers, both on the Laravel side. The chatbot-util 409 is correct behavior — it stays as protection. The Laravel side now stops putting the user in a position to trigger it.

### 1. Front-end — `resources/views/integrations/facebook/complete.blade.php`
After a successful save, redirect the user to `/integrations` after 1.5s so the state URL is no longer reachable and cannot be re-submitted.

```js
setTimeout(() => { window.location.href = @json($integrationsUrl); }, 1500);
```

### 2. Back-end — `IntegrationConfigController::saveFacebookIntegration`
Short-circuit when the integration already has `facebook_connection_status=connected`. `integration_id` is added as an optional field on the request to enable the lookup. If a connection already exists, return `success: true` with the saved page info and skip the proxy to chatbot-util entirely.

Logs `facebook_integration_save_skipped_already_connected` for traceability.

## Verification
- `php -l` passes on the controller
- Manual flow: connect -> select page -> success -> auto-redirect to /integrations
- Re-clicking the save endpoint on an already-connected integration no longer reaches chatbot-util