### PR TITLE
fix: add missing closing brace for syncFaqVector method

### DIFF
--- a/src/Http/Controllers/IntegrationConfigController.php
+++ b/src/Http/Controllers/IntegrationConfigController.php
@@ -670,6 +670,8 @@ class IntegrationConfigController extends Controller
 
             return back()->with('error', 'Failed to queue FAQ vector re-index.');
         }
+    }
+    
     protected function syncFacebookConnectionMeta(
         Integration $integration,
         array $responsePayload,


### PR DESCRIPTION
Fixes #14

## Bug
syncFaqVector()'s closing brace was missing in main, causing a
ParseError on /configure page. Likely lost when
syncFacebookConnectionMeta() was merged directly after it without
properly closing the previous method.

## Fix
Added the missing `}` after the catch block, before
syncFacebookConnectionMeta() begins.

## Verified
- php -l confirms no syntax errors after fix
- Tested locally — /configure page loads correctly, FAQ button
  and re-index functionality both confirmed working end to end