### PR TITLE
fix: FAQ re-index button visibility

### DIFF
--- a/src/Http/Controllers/IntegrationConfigController.php
+++ b/src/Http/Controllers/IntegrationConfigController.php
@@ -34,7 +34,7 @@ class IntegrationConfigController extends Controller
             $websiteUrl = $integration->getMeta('website_url');
             $consumerKey = $integration->getMeta('consumer_key');
             $consumerSecret = $integration->getMeta('consumer_secret');
-            $isActive = $integration->getMeta('is_active');
+            $isActive = ($integration->status === Constants::ACTIVE);
             $chatbot_vector = $integration->getMeta('chatbot_vector');
             $humanHandoverEnabled = (string) $integration->getMeta(Constants::HUMAN_HANDOVER_ENABLED, 'false');
             $allowInternalTesting = (string) $integration->getMeta(Constants::ALLOW_INTERNAL_TESTING, 'false');


### PR DESCRIPTION
## What this fixes
FAQ re-index button and success banner on the WooCommerce configure
page never appeared, since they depended on an `is_active` meta key
that is never set anywhere in the codebase.

## Change
$isActive = $integration->getMeta('is_active');
→
$isActive = ($integration->status === Constants::ACTIVE);

## Verified
- status = active   → banner and button show
- status = inactive → banner and button hidden
- status = deleted  → banner and button hidden
- Confirmed via codebase search that this variable is isolated to
  this single page — no other feature, job, or scheduler depends on it

Closes #19 